### PR TITLE
Fixed support for continuous joints

### DIFF
--- a/src/urdf_loader.cpp
+++ b/src/urdf_loader.cpp
@@ -496,11 +496,15 @@ std::pair<OpenRAVE::KinBody::JointType, bool> URDFJointTypeToRaveJointType(int t
           joint_info->_vlowerlimit[0] = 0;
           joint_info->_vupperlimit[0] = 0;
       }
-      // This is a hack to get continuous joints to work. The limits default to
-      // [0, 0], which inserts a fixed joint.
-      else if (urdf_joint_type == urdf::Joint::CONTINUOUS) {
-          joint_info->_vlowerlimit[0] = -M_PI;
-          joint_info->_vupperlimit[0] =  M_PI;
+
+      // Ignore limits on continuous joints and set them to +/- infinity. This
+      // also solves a problem where continuous joints default to [ 0, 0 ]
+      // limits, which creates a fixed joint.
+      if (urdf_joint_type == urdf::Joint::CONTINUOUS) {
+          OpenRAVE::dReal const inf
+              = std::numeric_limits<OpenRAVE::dReal>::infinity();
+          joint_info->_vlowerlimit[0] = -inf;
+          joint_info->_vupperlimit[0] = +inf;
       }
       joint_infos.push_back(joint_info);
     }

--- a/src/urdf_loader.cpp
+++ b/src/urdf_loader.cpp
@@ -489,11 +489,21 @@ std::pair<OpenRAVE::KinBody::JointType, bool> URDFJointTypeToRaveJointType(int t
           joint_info->_vlowerlimit[0] = 0;
           joint_info->_vupperlimit[0] = 0;
       }
-      // Default to +/- 2*PI. This is the same default used by OpenRAVE.
+      // Default to +/- 2*PI. This is the same default used by OpenRAVE for
+      // revolute joints.
       else {
           joint_info->_vlowerlimit[0] = -M_PI;
           joint_info->_vupperlimit[0] =  M_PI;
       }
+
+      // Force continuous joints to have +/- PI limits. Otherwise, the internal
+      // _vcircularlowerlimit and _vcircularupperlimit values will be set to
+      // zero. This causes OpenRAVE::utils::NormalizeCircularAngle to crash.
+      if (urdf_joint_type == urdf::Joint::CONTINUOUS) {
+          joint_info->_vlowerlimit[0] = -M_PI;
+          joint_info->_vupperlimit[0] =  M_PI;
+      }
+
       joint_infos.push_back(joint_info);
     }
   }


### PR DESCRIPTION
There were several bugs related to continuous joints:

- Continuous joints with limits defined were being converted to revolute joints.
- `_bIsCircular` was not set on continuous joints.

This pull request fixes those bugs.