### PR TITLE
Remove openrave_catkin dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 project(or_urdf)
 
 find_package(catkin REQUIRED COMPONENTS
-    openrave_catkin
     roslib
     srdfdom
     urdf
 )
-catkin_package()
 
 find_package(Boost REQUIRED COMPONENTS
     filesystem
@@ -15,10 +13,17 @@ find_package(Boost REQUIRED COMPONENTS
 )
 find_package(OpenRAVE REQUIRED)
 
+catkin_package()
+catkin_add_env_hooks("20.${PROJECT_NAME}"
+   SHELLS sh
+   DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/catkin-env-hooks"
+)
+
 include_directories(
     "include/${PROJECT_NAME}"
     ${Boost_INCLUDE_DIRS}
     ${catkin_INCLUDE_DIRS}
+    ${OpenRAVE_INCLUDE_DIRS}
 )
 link_directories(
     ${Boost_LIBRARY_DIRS}
@@ -26,14 +31,25 @@ link_directories(
     ${OpenRAVE_LIBRARY_DIRS}
 )
 
-openrave_plugin("${PROJECT_NAME}_plugin"
+add_library("${PROJECT_NAME}_plugin" MODULE
     src/urdf_loader.cpp
 )
+set_target_properties(${PROJECT_NAME}_plugin PROPERTIES
+    PREFIX ""
+    COMPILE_FLAGS "${OpenRAVE_CXX_FLAGS}"
+    LINK_FLAGS "${OpenRAVE_LINK_FLAGS}"
+    LIBRARY_OUTPUT_DIRECTORY
+    "${CATKIN_DEVEL_PREFIX}/lib/openrave-${OpenRAVE_LIBRARY_SUFFIX}")
 target_link_libraries("${PROJECT_NAME}_plugin"
     ${catkin_LIBRARIES}
+    ${OpenRAVE_LIBRARIES}
 )
 
 if(CATKIN_ENABLE_TESTING)
     catkin_add_nosetests(tests)
 endif(CATKIN_ENABLE_TESTING)
+
+install(TARGETS "${PROJECT_NAME}_plugin"
+    LIBRARY DESTINATION "lib/openrave-${OpenRAVE_LIBRARY_SUFFIX}"
+)
 

--- a/catkin-env-hooks/20.or_urdf.sh.in
+++ b/catkin-env-hooks/20.or_urdf.sh.in
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# determine if we're in the devel or install space
+if [ "@DEVELSPACE@" = "True" -o "@DEVELSPACE@" = "true" ]
+then
+  PLUGINS=@CATKIN_DEVEL_PREFIX@/lib/openrave-@OpenRAVE_LIBRARY_SUFFIX@
+else
+  PLUGINS=@CMAKE_INSTALL_PREFIX@/lib/openrave-@OpenRAVE_LIBRARY_SUFFIX@
+fi
+
+# append to paths (if not already there)
+# from http://unix.stackexchange.com/a/124447
+case ":${OPENRAVE_PLUGINS:=$PLUGINS}:" in
+    *:$PLUGINS:*) ;;
+    *) OPENRAVE_PLUGINS="$OPENRAVE_PLUGINS:$PLUGINS" ;;
+esac
+
+export OPENRAVE_PLUGINS

--- a/package.xml
+++ b/package.xml
@@ -12,12 +12,10 @@
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>boost</build_depend>
-  <build_depend>openrave_catkin</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>srdfdom</build_depend>
   <build_depend>urdf</build_depend>
   <run_depend>boost</run_depend>
-  <run_depend>openrave_catkin</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>srdfdom</run_depend>
   <run_depend>urdf</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -12,10 +12,12 @@
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>boost</build_depend>
+  <build_depend>openrave</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>srdfdom</build_depend>
   <build_depend>urdf</build_depend>
   <run_depend>boost</run_depend>
+  <run_depend>openrave</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>srdfdom</run_depend>
   <run_depend>urdf</run_depend>


### PR DESCRIPTION
This might be controversial, but I got tired cloning `openrave_catkin` every time I set up a new workspace when it doesn't really do much, so this PR just pulls the plugin boilerplate into the package and removes the dependency.  (It's fine by me if this doesn't get merged ... I'm happy to pull it into my fork instead.)