### PR TITLE
Changed installation destination

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ set_target_properties(${PROJECT_NAME}_plugin PROPERTIES
     COMPILE_FLAGS "${OpenRAVE_CXX_FLAGS}"
     LINK_FLAGS "${OpenRAVE_LINK_FLAGS}"
     LIBRARY_OUTPUT_DIRECTORY
-    "${CATKIN_DEVEL_PREFIX}/lib/openrave-${OpenRAVE_LIBRARY_SUFFIX}")
+    "${CATKIN_DEVEL_PREFIX}/share/openrave-${OpenRAVE_LIBRARY_SUFFIX}/plugins")
 target_link_libraries("${PROJECT_NAME}_plugin"
     ${catkin_LIBRARIES}
     ${TinyXML2_LIBRARIES}
@@ -57,6 +57,6 @@ if(CATKIN_ENABLE_TESTING)
 endif(CATKIN_ENABLE_TESTING)
 
 install(TARGETS "${PROJECT_NAME}_plugin"
-    LIBRARY DESTINATION "lib/openrave-${OpenRAVE_LIBRARY_SUFFIX}"
+    LIBRARY DESTINATION "share/openrave-${OpenRAVE_LIBRARY_SUFFIX}/plugins"
 )
 

--- a/src/boostfs_helpers.h
+++ b/src/boostfs_helpers.h
@@ -17,36 +17,43 @@ namespace boost
   namespace filesystem3
 #endif
   {
-    template < >
-    path& path::append< typename path::iterator >( typename path::iterator begin, typename path::iterator end, const codecvt_type& cvt)
-    { 
-      for( ; begin != end ; ++begin )
-        *this /= *begin;
-      return *this;
-    }
+    #if BOOST_VERSION > 106000 
+        // From Boost 1.60+ there is a built-in function for this (boost::filesystem::relative).
+        boost::filesystem::path make_relative(boost::filesystem::path a_From, boost::filesystem::path a_To)
+        {
+            return boost::filesystem::relative(a_From, a_To);
+        }
+    #else
+        template < >
+        path& path::append< typename path::iterator >( typename path::iterator begin, typename path::iterator end, const codecvt_type& cvt)
+        { 
+        for( ; begin != end ; ++begin )
+            *this /= *begin;
+        return *this;
+        }
     
-    // Return path when appended to a_From will resolve to same as a_To
-    boost::filesystem::path make_relative( boost::filesystem::path a_From, boost::filesystem::path a_To )
-    {
-      a_From = boost::filesystem::absolute( a_From ); a_To = boost::filesystem::absolute( a_To );
-      boost::filesystem::path ret;
-      boost::filesystem::path::const_iterator itrFrom( a_From.begin() ), itrTo( a_To.begin() );
-      
-      // Find common base
-      for( boost::filesystem::path::const_iterator toEnd( a_To.end() ), fromEnd( a_From.end() ) ; 
-           itrFrom != fromEnd && itrTo != toEnd && *itrFrom == *itrTo; ++itrFrom, ++itrTo );
-      
-      // Navigate backwards in directory to reach previously found base
-      for( boost::filesystem::path::const_iterator fromEnd( a_From.end() ); itrFrom != fromEnd; ++itrFrom ) {
-        if( (*itrFrom) != "." )
-          ret /= "..";
-      }
-      
-      // Now navigate down the directory branch
-      ret.append( itrTo, a_To.end() );
-      return ret;
-    }
+        // Return path when appended to a_From will resolve to same as a_To
+        boost::filesystem::path make_relative( boost::filesystem::path a_From, boost::filesystem::path a_To )
+        {
+        a_From = boost::filesystem::absolute( a_From ); a_To = boost::filesystem::absolute( a_To );
+        boost::filesystem::path ret;
+        boost::filesystem::path::const_iterator itrFrom( a_From.begin() ), itrTo( a_To.begin() );
+        
+        // Find common base
+        for( boost::filesystem::path::const_iterator toEnd( a_To.end() ), fromEnd( a_From.end() ) ; 
+            itrFrom != fromEnd && itrTo != toEnd && *itrFrom == *itrTo; ++itrFrom, ++itrTo );
+        
+        // Navigate backwards in directory to reach previously found base
+        for( boost::filesystem::path::const_iterator fromEnd( a_From.end() ); itrFrom != fromEnd; ++itrFrom ) {
+            if( (*itrFrom) != "." )
+            ret /= "..";
+        }
+        
+        // Now navigate down the directory branch
+        ret.append( itrTo, a_To.end() );
+        return ret;
+        }
+    #endif
   } 
 }
-
 


### PR DESCRIPTION
Changed from lib/openrave-0.9 to share/openrave-0.9/plugins to be consistent with all openrave catkin plugins.

Most of the plugins (see or_rviz) are "installed" in `~/catkin_ws/devel/share/openrave-0.9/plugins` and hence the path for `OPENRAVE_PLUGINS` is:
```
export OPENRAVE_PLUGINS=$OPENRAVE_PLUGINS:~/catkin_ws/devel/share/openrave-0.9/plugins
```

This change will cause the installation of or_urdf to also go in `~/catkin_ws/devel/share/openrave-0.9/plugins` instead of `lib/openrave-0.9` and hence there is no need to add another path to `OPENRAVE_PLUGINS`.

Proof:
```
rafael@rafael-CS-B:~/catkin_ws/src/or_urdf$ openrave --listplugins | grep URDF
  URDF - /home/rafael/catkin_ws/devel/share/openrave-0.9/plugins/or_urdf_plugin.so
```
