### PR TITLE
Added support for Boost 1.60+

### DIFF
--- a/src/boostfs_helpers.h
+++ b/src/boostfs_helpers.h
@@ -17,36 +17,43 @@ namespace boost
   namespace filesystem3
 #endif
   {
-    template < >
-    path& path::append< typename path::iterator >( typename path::iterator begin, typename path::iterator end, const codecvt_type& cvt)
-    { 
-      for( ; begin != end ; ++begin )
-        *this /= *begin;
-      return *this;
-    }
+    #if BOOST_VERSION > 106000 
+        // From Boost 1.60+ there is a built-in function for this (boost::filesystem::relative).
+        boost::filesystem::path make_relative(boost::filesystem::path a_From, boost::filesystem::path a_To)
+        {
+            return boost::filesystem::relative(a_From, a_To);
+        }
+    #else
+        template < >
+        path& path::append< typename path::iterator >( typename path::iterator begin, typename path::iterator end, const codecvt_type& cvt)
+        { 
+        for( ; begin != end ; ++begin )
+            *this /= *begin;
+        return *this;
+        }
     
-    // Return path when appended to a_From will resolve to same as a_To
-    boost::filesystem::path make_relative( boost::filesystem::path a_From, boost::filesystem::path a_To )
-    {
-      a_From = boost::filesystem::absolute( a_From ); a_To = boost::filesystem::absolute( a_To );
-      boost::filesystem::path ret;
-      boost::filesystem::path::const_iterator itrFrom( a_From.begin() ), itrTo( a_To.begin() );
-      
-      // Find common base
-      for( boost::filesystem::path::const_iterator toEnd( a_To.end() ), fromEnd( a_From.end() ) ; 
-           itrFrom != fromEnd && itrTo != toEnd && *itrFrom == *itrTo; ++itrFrom, ++itrTo );
-      
-      // Navigate backwards in directory to reach previously found base
-      for( boost::filesystem::path::const_iterator fromEnd( a_From.end() ); itrFrom != fromEnd; ++itrFrom ) {
-        if( (*itrFrom) != "." )
-          ret /= "..";
-      }
-      
-      // Now navigate down the directory branch
-      ret.append( itrTo, a_To.end() );
-      return ret;
-    }
+        // Return path when appended to a_From will resolve to same as a_To
+        boost::filesystem::path make_relative( boost::filesystem::path a_From, boost::filesystem::path a_To )
+        {
+        a_From = boost::filesystem::absolute( a_From ); a_To = boost::filesystem::absolute( a_To );
+        boost::filesystem::path ret;
+        boost::filesystem::path::const_iterator itrFrom( a_From.begin() ), itrTo( a_To.begin() );
+        
+        // Find common base
+        for( boost::filesystem::path::const_iterator toEnd( a_To.end() ), fromEnd( a_From.end() ) ; 
+            itrFrom != fromEnd && itrTo != toEnd && *itrFrom == *itrTo; ++itrFrom, ++itrTo );
+        
+        // Navigate backwards in directory to reach previously found base
+        for( boost::filesystem::path::const_iterator fromEnd( a_From.end() ); itrFrom != fromEnd; ++itrFrom ) {
+            if( (*itrFrom) != "." )
+            ret /= "..";
+        }
+        
+        // Now navigate down the directory branch
+        ret.append( itrTo, a_To.end() );
+        return ret;
+        }
+    #endif
   } 
 }
-
 


### PR DESCRIPTION
When compiling catkin with Boost 1.60+ (tested with Boost 1.64) there were errors to the function definition:
```cpp
boost::filesystem::path make_relative( boost::filesystem::path a_From, boost::filesystem::path a_To )
```

Working function definition for Boost 1.60+ added.

This won't break Boost <1.60.

Tested with Boost 1.54 and Boost 1.64.