### PR TITLE
Fixed compilation bugs while using catkin_make for ros-melodic

### DIFF
--- a/src/catkin_finder.cpp
+++ b/src/catkin_finder.cpp
@@ -28,7 +28,7 @@ std::string getPackageNameFromXML(const std::string& _path)
   if (document.LoadFile(_path.c_str()))
   {
     RAVELOG_WARN("Failed loading package.xml file '%s': %s\n",
-           _path.c_str(), document.GetErrorStr1());
+           _path.c_str(), document.ErrorStr());
     return "";
   }
 


### PR DESCRIPTION
You can make a new branch for melodic fixes. I haven't checked if the fixes are backward compatible, but it definitely works with ros-melodic (ubuntu 18.04) now.